### PR TITLE
Introduce mediator handlers with logging

### DIFF
--- a/HCM/Features/Identity/Logout/Endpoint.cs
+++ b/HCM/Features/Identity/Logout/Endpoint.cs
@@ -1,31 +1,41 @@
 using FastEndpoints;
-using HCM.Infrastructure;
-using Microsoft.EntityFrameworkCore;
+using MediatR;
+using Microsoft.Extensions.Logging;
 
 namespace HCM.Features.Identity.Logout;
 
 public sealed class Endpoint : EndpointWithoutRequest
 {
-    private readonly ApplicationDbContext context;
-    
-    public Endpoint(ApplicationDbContext context) => this.context = context;
+    private readonly IMediator mediator;
+    private readonly ILogger<Endpoint> logger;
+
+    public Endpoint(IMediator mediator, ILogger<Endpoint> logger)
+    {
+        this.mediator = mediator;
+        this.logger = logger;
+    }
     
     public override void Configure() => Post("api/auth/logout");
     
     public override async Task HandleAsync(CancellationToken ct)
     {
         string? cookieRefreshToken = HttpContext.Request.Cookies["refreshToken"];
-        
-        if (string.IsNullOrEmpty(cookieRefreshToken))
+
+        try
         {
+            var result = await mediator.Send(new LogoutCommand(cookieRefreshToken), ct);
+            if (result.IsFailure)
+            {
+                await SendResultAsync(Results.Problem(detail: result.Error.Description, statusCode: result.Error.Code));
+                return;
+            }
+
             await SendNoContentAsync(ct);
-            return;
         }
-        
-        await context.RefreshTokens
-            .Where(t => t.Token == cookieRefreshToken)
-            .ExecuteDeleteAsync(ct);
-        
-        await SendNoContentAsync(ct);
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error during logout");
+            ThrowError("An unexpected error occurred");
+        }
     }
 }

--- a/HCM/Features/Identity/Logout/LogoutCommand.cs
+++ b/HCM/Features/Identity/Logout/LogoutCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using HCM.Shared.Results;
+
+namespace HCM.Features.Identity.Logout;
+
+public sealed record LogoutCommand(string? RefreshToken) : IRequest<ResultWithoutValue>;

--- a/HCM/Features/Identity/Logout/LogoutCommandHandler.cs
+++ b/HCM/Features/Identity/Logout/LogoutCommandHandler.cs
@@ -1,0 +1,38 @@
+using HCM.Infrastructure;
+using HCM.Shared.Results;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HCM.Features.Identity.Logout;
+
+public sealed class LogoutCommandHandler : IRequestHandler<LogoutCommand, ResultWithoutValue>
+{
+    private readonly ApplicationDbContext context;
+    private readonly ILogger<LogoutCommandHandler> logger;
+
+    public LogoutCommandHandler(ApplicationDbContext context, ILogger<LogoutCommandHandler> logger)
+    {
+        this.context = context;
+        this.logger = logger;
+    }
+
+    public async Task<ResultWithoutValue> Handle(LogoutCommand request, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrEmpty(request.RefreshToken))
+        {
+            return ResultWithoutValue.Success();
+        }
+
+        try
+        {
+            await context.RefreshTokens.Where(t => t.Token == request.RefreshToken).ExecuteDeleteAsync(cancellationToken);
+            return ResultWithoutValue.Success();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error logging out");
+            return ResultWithoutValue.Failure("Failed to logout");
+        }
+    }
+}

--- a/HCM/Features/Identity/Refresh/RefreshTokenCommand.cs
+++ b/HCM/Features/Identity/Refresh/RefreshTokenCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using HCM.Shared.Results;
+
+namespace HCM.Features.Identity.Refresh;
+
+public sealed record RefreshTokenCommand(string RefreshToken) : IRequest<Result<TokenPair>>;

--- a/HCM/Features/Identity/Refresh/RefreshTokenCommandHandler.cs
+++ b/HCM/Features/Identity/Refresh/RefreshTokenCommandHandler.cs
@@ -1,0 +1,49 @@
+using HCM.Domain.Persons;
+using HCM.Shared.Results;
+using HCM.Infrastructure;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HCM.Features.Identity.Refresh;
+
+public sealed class RefreshTokenCommandHandler : IRequestHandler<RefreshTokenCommand, Result<TokenPair>>
+{
+    private readonly TokenIssuer tokenIssuer;
+    private readonly ApplicationDbContext context;
+    private readonly ILogger<RefreshTokenCommandHandler> logger;
+
+    public RefreshTokenCommandHandler(TokenIssuer tokenIssuer, ApplicationDbContext context, ILogger<RefreshTokenCommandHandler> logger)
+    {
+        this.tokenIssuer = tokenIssuer;
+        this.context = context;
+        this.logger = logger;
+    }
+
+    public async Task<Result<TokenPair>> Handle(RefreshTokenCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var storedRefreshToken = await context.RefreshTokens.FirstOrDefaultAsync(t => t.Token == request.RefreshToken, cancellationToken);
+
+            if (!RefreshTokenValidator.IsRefreshTokenValid(storedRefreshToken))
+            {
+                return Result<TokenPair>.Invalid("Invalid refresh token");
+            }
+
+            var user = await context.Persons.AsNoTracking().SingleOrDefaultAsync(u => u.Id == storedRefreshToken!.PersonId, cancellationToken);
+            if (user is null)
+            {
+                return Result<TokenPair>.Invalid("Invalid refresh token");
+            }
+
+            var tokenPair = await tokenIssuer.IssueNewTokensAsync(user, storedRefreshToken, cancellationToken);
+            return Result<TokenPair>.Success(tokenPair);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error refreshing token");
+            return Result<TokenPair>.Failure("Failed to refresh token");
+        }
+    }
+}

--- a/HCM/Features/Identity/Signup/SignupCommand.cs
+++ b/HCM/Features/Identity/Signup/SignupCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using HCM.Shared.Results;
+
+namespace HCM.Features.Identity.Signup;
+
+public sealed record SignupCommand(SignupRequest Request) : IRequest<Result<TokenPair>>;

--- a/HCM/Features/Identity/Signup/SignupCommandHandler.cs
+++ b/HCM/Features/Identity/Signup/SignupCommandHandler.cs
@@ -1,0 +1,52 @@
+using HCM.Domain.Identity;
+using HCM.Domain.Persons;
+using HCM.Features.Identity.Contracts;
+using HCM.Shared;
+using HCM.Shared.Results;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+
+namespace HCM.Features.Identity.Signup;
+
+public sealed class SignupCommandHandler : IRequestHandler<SignupCommand, Result<TokenPair>>
+{
+    private readonly PersonCreator personCreator;
+    private readonly TokenIssuer tokenIssuer;
+    private readonly IPasswordHasher<Person> passwordHasher;
+    private readonly ILogger<SignupCommandHandler> logger;
+
+    public SignupCommandHandler(PersonCreator personCreator, TokenIssuer tokenIssuer, IPasswordHasher<Person> passwordHasher, ILogger<SignupCommandHandler> logger)
+    {
+        this.personCreator = personCreator;
+        this.tokenIssuer = tokenIssuer;
+        this.passwordHasher = passwordHasher;
+        this.logger = logger;
+    }
+
+    public async Task<Result<TokenPair>> Handle(SignupCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var r = request.Request;
+            var person = Person.Create(r.FirstName, r.LastName, r.Email, r.JobTitle, r.Salary, r.Department,
+                ApplicationRoles.Employee, passwordHasher, r.Password);
+
+            var creationResult = await personCreator.Create(person, cancellationToken);
+
+            if (creationResult.IsFailure)
+            {
+                logger.LogWarning("Signup failed: {Error}", creationResult.Error.Description);
+                return creationResult.AsError<TokenPair>();
+            }
+
+            var tokenPair = await tokenIssuer.IssueNewTokensAsync(creationResult.Value, null, cancellationToken);
+            return Result<TokenPair>.Success(tokenPair);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error during signup");
+            return Result<TokenPair>.Failure("Failed to signup");
+        }
+    }
+}

--- a/HCM/Features/Persons/Create/CreatePersonCommand.cs
+++ b/HCM/Features/Persons/Create/CreatePersonCommand.cs
@@ -1,0 +1,7 @@
+using HCM.Shared.Contracts;
+using HCM.Shared.Results;
+using MediatR;
+
+namespace HCM.Features.Persons.Create;
+
+public sealed record CreatePersonCommand(CreatePersonRequest Request) : IRequest<Result<PersonResponse>>;

--- a/HCM/Features/Persons/Create/CreatePersonCommandHandler.cs
+++ b/HCM/Features/Persons/Create/CreatePersonCommandHandler.cs
@@ -1,0 +1,48 @@
+using HCM.Domain.Persons;
+using HCM.Shared;
+using HCM.Shared.Contracts;
+using HCM.Shared.Results;
+using MediatR;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+
+namespace HCM.Features.Persons.Create;
+
+public sealed class CreatePersonCommandHandler : IRequestHandler<CreatePersonCommand, Result<PersonResponse>>
+{
+    private readonly PersonCreator personCreator;
+    private readonly IPasswordHasher<Person> passwordHasher;
+    private readonly ILogger<CreatePersonCommandHandler> logger;
+
+    public CreatePersonCommandHandler(PersonCreator personCreator, IPasswordHasher<Person> passwordHasher, ILogger<CreatePersonCommandHandler> logger)
+    {
+        this.personCreator = personCreator;
+        this.passwordHasher = passwordHasher;
+        this.logger = logger;
+    }
+
+    public async Task<Result<PersonResponse>> Handle(CreatePersonCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var r = request.Request;
+            var person = Person.Create(r.FirstName, r.LastName, r.Email, r.JobTitle, r.Salary, r.Department,
+                r.Role, passwordHasher, r.Password);
+
+            var result = await personCreator.Create(person, cancellationToken);
+
+            if (result.IsFailure)
+            {
+                logger.LogWarning("Failed to create person: {Error}", result.Error.Description);
+                return result.AsError<PersonResponse>();
+            }
+
+            return Result<PersonResponse>.Success(person.ToPersonResponse());
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Exception during person creation");
+            return Result<PersonResponse>.Failure("An error occurred while creating the person");
+        }
+    }
+}

--- a/HCM/Features/Persons/Delete/DeletePersonCommand.cs
+++ b/HCM/Features/Persons/Delete/DeletePersonCommand.cs
@@ -1,0 +1,6 @@
+using MediatR;
+using HCM.Shared.Results;
+
+namespace HCM.Features.Persons.Delete;
+
+public sealed record DeletePersonCommand(Guid PersonId) : IRequest<ResultWithoutValue>;

--- a/HCM/Features/Persons/Delete/DeletePersonCommandHandler.cs
+++ b/HCM/Features/Persons/Delete/DeletePersonCommandHandler.cs
@@ -1,0 +1,38 @@
+using HCM.Infrastructure;
+using HCM.Shared.Results;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HCM.Features.Persons.Delete;
+
+public sealed class DeletePersonCommandHandler : IRequestHandler<DeletePersonCommand, ResultWithoutValue>
+{
+    private readonly ApplicationDbContext context;
+    private readonly ILogger<DeletePersonCommandHandler> logger;
+
+    public DeletePersonCommandHandler(ApplicationDbContext context, ILogger<DeletePersonCommandHandler> logger)
+    {
+        this.context = context;
+        this.logger = logger;
+    }
+
+    public async Task<ResultWithoutValue> Handle(DeletePersonCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var person = await context.Persons.FirstOrDefaultAsync(p => p.Id == request.PersonId, cancellationToken);
+            if (person == null)
+                return ResultWithoutValue.NotFound("Person not found");
+
+            context.Persons.Remove(person);
+            await context.SaveChangesAsync(cancellationToken);
+            return ResultWithoutValue.Success();
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error deleting person");
+            return ResultWithoutValue.Failure("Failed to delete person");
+        }
+    }
+}

--- a/HCM/Features/Persons/GetAll/GetPersonsQuery.cs
+++ b/HCM/Features/Persons/GetAll/GetPersonsQuery.cs
@@ -1,0 +1,6 @@
+using HCM.Shared.Results;
+using MediatR;
+
+namespace HCM.Features.Persons.GetAll;
+
+public sealed record GetPersonsQuery(int Page, int PageSize, string Role, string? Department) : IRequest<Result<PagedResponse>>;

--- a/HCM/Features/Persons/GetAll/GetPersonsQueryHandler.cs
+++ b/HCM/Features/Persons/GetAll/GetPersonsQueryHandler.cs
@@ -1,0 +1,57 @@
+using HCM.Domain.Identity;
+using HCM.Infrastructure;
+using HCM.Shared.Contracts;
+using HCM.Shared.Results;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HCM.Features.Persons.GetAll;
+
+public sealed class GetPersonsQueryHandler : IRequestHandler<GetPersonsQuery, Result<PagedResponse>>
+{
+    private readonly ApplicationDbContext context;
+    private readonly ILogger<GetPersonsQueryHandler> logger;
+
+    public GetPersonsQueryHandler(ApplicationDbContext context, ILogger<GetPersonsQueryHandler> logger)
+    {
+        this.context = context;
+        this.logger = logger;
+    }
+
+    public async Task<Result<PagedResponse>> Handle(GetPersonsQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var personsQueryable = context.Persons.AsNoTracking().AsQueryable();
+            if (request.Role == ApplicationRoles.Manager)
+            {
+                personsQueryable = personsQueryable.Where(p => p.Department == request.Department);
+            }
+
+            int totalCount = await personsQueryable.CountAsync(cancellationToken);
+
+            var persons = await personsQueryable
+                .OrderBy(p => p.Id)
+                .Skip((request.Page - 1) * request.PageSize)
+                .Take(request.PageSize)
+                .Select(p => p.ToPersonResponse())
+                .ToListAsync(cancellationToken);
+
+            var response = new PagedResponse
+            {
+                Persons = persons,
+                Page = request.Page,
+                PageSize = request.PageSize,
+                TotalCount = totalCount
+            };
+
+            return Result<PagedResponse>.Success(response);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting persons");
+            return Result<PagedResponse>.Failure("Failed to retrieve persons");
+        }
+    }
+}

--- a/HCM/Features/Persons/GetById/Endpoint.cs
+++ b/HCM/Features/Persons/GetById/Endpoint.cs
@@ -1,41 +1,51 @@
 ﻿using FastEndpoints;
-using HCM.Infrastructure;
 using HCM.Shared.Contracts;
+using MediatR;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace HCM.Features.Persons.GetById;
 
 public sealed class Endpoint : Endpoint<GetPersonByIdRequest, PersonResponse>
 {
-    private readonly ApplicationDbContext context;
+    private readonly IMediator mediator;
     private readonly IAuthorizationService authorizationService;
-    
-    public Endpoint(ApplicationDbContext context, IAuthorizationService authorizationService)
+    private readonly ILogger<Endpoint> logger;
+
+    public Endpoint(IMediator mediator, IAuthorizationService authorizationService, ILogger<Endpoint> logger)
     {
-        this.context = context;
+        this.mediator = mediator;
         this.authorizationService = authorizationService;
+        this.logger = logger;
     }
     
     public override void Configure() => Get(EndpointSettings.DefaultName + "/{PersonId}");
     
     public override async Task HandleAsync(GetPersonByIdRequest req, CancellationToken ct)
     {
-        var person = await context.Persons.AsNoTracking().FirstOrDefaultAsync(p => p.Id == req.PersonId, cancellationToken: ct);
-        if (person == null)
+        try
         {
-            await SendNotFoundAsync(ct);
-            return;
+            var result = await mediator.Send(new GetPersonByIdQuery(req.PersonId), ct);
+            if (result.IsFailure)
+            {
+                await SendNotFoundAsync(ct);
+                return;
+            }
+
+            var person = result.Value;
+            var authResult = await authorizationService.AuthorizeAsync(User, person, "CanViewPerson");
+            if (!authResult.Succeeded)
+            {
+                await SendForbiddenAsync(ct);
+                return;
+            }
+
+            await SendOkAsync(person.ToPersonResponse(), ct);
         }
-        
-        var result = await authorizationService.AuthorizeAsync(User, person, "CanViewPerson");
-        
-        if (!result.Succeeded)
+        catch (Exception ex)
         {
-            await SendForbiddenAsync(ct);
-            return;
+            logger.LogError(ex, "Error retrieving person by id");
+            ThrowError("An unexpected error occurred");
         }
-        
-        await SendOkAsync(person.ToPersonResponse(), ct);
     }
 }

--- a/HCM/Features/Persons/GetById/GetPersonByIdQuery.cs
+++ b/HCM/Features/Persons/GetById/GetPersonByIdQuery.cs
@@ -1,0 +1,7 @@
+using HCM.Domain.Persons;
+using HCM.Shared.Results;
+using MediatR;
+
+namespace HCM.Features.Persons.GetById;
+
+public sealed record GetPersonByIdQuery(Guid PersonId) : IRequest<Result<Person>>;

--- a/HCM/Features/Persons/GetById/GetPersonByIdQueryHandler.cs
+++ b/HCM/Features/Persons/GetById/GetPersonByIdQueryHandler.cs
@@ -1,0 +1,36 @@
+using HCM.Domain.Persons;
+using HCM.Infrastructure;
+using HCM.Shared.Results;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HCM.Features.Persons.GetById;
+
+public sealed class GetPersonByIdQueryHandler : IRequestHandler<GetPersonByIdQuery, Result<Person>>
+{
+    private readonly ApplicationDbContext context;
+    private readonly ILogger<GetPersonByIdQueryHandler> logger;
+
+    public GetPersonByIdQueryHandler(ApplicationDbContext context, ILogger<GetPersonByIdQueryHandler> logger)
+    {
+        this.context = context;
+        this.logger = logger;
+    }
+
+    public async Task<Result<Person>> Handle(GetPersonByIdQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var person = await context.Persons.AsNoTracking().FirstOrDefaultAsync(p => p.Id == request.PersonId, cancellationToken);
+            return person is null
+                ? Result<Person>.NotFound("Person not found")
+                : Result<Person>.Success(person);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error getting person by id");
+            return Result<Person>.Failure("Failed to retrieve person");
+        }
+    }
+}

--- a/HCM/Features/Persons/Update/Endpoint.cs
+++ b/HCM/Features/Persons/Update/Endpoint.cs
@@ -1,23 +1,25 @@
 ﻿using System.Security.Claims;
 using FastEndpoints;
 using HCM.Domain.Identity;
-using HCM.Domain.Persons;
-using HCM.Infrastructure;
 using HCM.Shared.Contracts;
+using MediatR;
+using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 
 namespace HCM.Features.Persons.Update;
 
-public sealed class Endpoint :  Endpoint<UpdatePersonRequest,PersonResponse>
+public sealed class Endpoint : Endpoint<UpdatePersonRequest, PersonResponse>
 {
-    private readonly ApplicationDbContext context;
+    private readonly IMediator mediator;
     private readonly IAuthorizationService authorizationService;
-    
-    public Endpoint(ApplicationDbContext context, IAuthorizationService authorizationService)
+    private readonly ILogger<Endpoint> logger;
+
+    public Endpoint(IMediator mediator, IAuthorizationService authorizationService, ILogger<Endpoint> logger)
     {
-        this.context = context;
+        this.mediator = mediator;
         this.authorizationService = authorizationService;
+        this.logger = logger;
     }
     
     public override void Configure()
@@ -28,25 +30,37 @@ public sealed class Endpoint :  Endpoint<UpdatePersonRequest,PersonResponse>
     
     public override async Task HandleAsync(UpdatePersonRequest req, CancellationToken ct)
     {
-        var person = await context.Persons.FirstOrDefaultAsync(p => p.Id == req.PersonId, cancellationToken: ct);
-        if (person == null)
+        try
         {
-            await SendNotFoundAsync(ct);
-            return;
+            var getResult = await mediator.Send(new GetPersonByIdQuery(req.PersonId), ct);
+            if (getResult.IsFailure)
+            {
+                await SendNotFoundAsync(ct);
+                return;
+            }
+
+            var person = getResult.Value;
+            var auth = await authorizationService.AuthorizeAsync(User, person, "CanEditPerson");
+            if (!auth.Succeeded)
+            {
+                await SendForbiddenAsync(ct);
+                return;
+            }
+
+            var updateResult = await mediator.Send(new UpdatePersonCommand(req, User.FindFirstValue(ClaimTypes.Role)!), ct);
+
+            if (updateResult.IsFailure)
+            {
+                await SendResultAsync(Results.Problem(detail: updateResult.Error.Description, statusCode: updateResult.Error.Code));
+                return;
+            }
+
+            await SendOkAsync(updateResult.Value, ct);
         }
-        
-        var result = await authorizationService.AuthorizeAsync(User, person, "CanEditPerson");
-        
-        if (!result.Succeeded)
+        catch (Exception ex)
         {
-            await SendForbiddenAsync(ct);
-            return;
+            logger.LogError(ex, "Error updating person");
+            ThrowError("An unexpected error occurred");
         }
-        
-        person.Update(req, User.FindFirstValue(ClaimTypes.Role)!);
-        
-        await context.SaveChangesAsync(ct);
-        
-        await SendOkAsync(person.ToPersonResponse(), ct);
     }
 }

--- a/HCM/Features/Persons/Update/UpdatePersonCommand.cs
+++ b/HCM/Features/Persons/Update/UpdatePersonCommand.cs
@@ -1,0 +1,7 @@
+using HCM.Shared.Contracts;
+using HCM.Shared.Results;
+using MediatR;
+
+namespace HCM.Features.Persons.Update;
+
+public sealed record UpdatePersonCommand(UpdatePersonRequest Request, string UserRole) : IRequest<Result<PersonResponse>>;

--- a/HCM/Features/Persons/Update/UpdatePersonCommandHandler.cs
+++ b/HCM/Features/Persons/Update/UpdatePersonCommandHandler.cs
@@ -1,0 +1,40 @@
+using HCM.Domain.Persons;
+using HCM.Infrastructure;
+using HCM.Shared.Contracts;
+using HCM.Shared.Results;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace HCM.Features.Persons.Update;
+
+public sealed class UpdatePersonCommandHandler : IRequestHandler<UpdatePersonCommand, Result<PersonResponse>>
+{
+    private readonly ApplicationDbContext context;
+    private readonly ILogger<UpdatePersonCommandHandler> logger;
+
+    public UpdatePersonCommandHandler(ApplicationDbContext context, ILogger<UpdatePersonCommandHandler> logger)
+    {
+        this.context = context;
+        this.logger = logger;
+    }
+
+    public async Task<Result<PersonResponse>> Handle(UpdatePersonCommand request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var person = await context.Persons.FirstOrDefaultAsync(p => p.Id == request.Request.PersonId, cancellationToken);
+            if (person == null)
+                return Result<PersonResponse>.NotFound("Person not found");
+
+            person.Update(request.Request, request.UserRole);
+            await context.SaveChangesAsync(cancellationToken);
+            return Result<PersonResponse>.Success(person.ToPersonResponse());
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Error updating person");
+            return Result<PersonResponse>.Failure("Failed to update person");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add Mediatr command/query handlers for person and identity features
- update endpoints to send commands and queries
- log exceptions and return meaningful errors

## Testing
- `dotnet test ./HCM.Tests/HCM.Tests.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cd4cf1bec832588d5d4127404c5ab